### PR TITLE
feat: error handling for the list fetch

### DIFF
--- a/src/routes/nodes/+page.svelte
+++ b/src/routes/nodes/+page.svelte
@@ -4,25 +4,34 @@
   const { nodes } = data;
 </script>
 
-<article class="w-full">
+<article class="flex min-h-screen w-full flex-col">
   <header
     class="bg-black px-8 py-4 text-white md:fixed md:top-0 md:right-0 md:left-0 md:h-20 md:shadow-xl"
   >
-    <h1 class="flex justify-center text-lg">Top Lightning Network Nodes</h1>
+    <h1 id="header-title" class="flex justify-center text-lg">Top Lightning Network Nodes</h1>
     <p class="flex justify-center text-sm/8">
       Ordered by Connectivity <a href="#fn1" aria-describedby="fn1" class="underline">*</a>
     </p>
   </header>
-  <a id="list-header" class="md:block md:h-30" />
-  <ol class="bg-white md:m-auto md:max-w-2/3">
-    {#each nodes as node}
-      <li class="flex justify-between border-b border-zinc-500 p-2">
-        <dd class="max-w-2/3 truncate">{node.alias}</dd>
-        <dt class="text-gray-600">{node.channels}</dt>
-      </li>
-    {/each}
-  </ol>
-  <footer class="bg-black text-sm text-white">
+  <div class="grow">
+    <a id="list-header" class="md:block md:h-30" aria-labelledby="header-title"></a>
+    {#if data.errorMessage === null}
+      <ol class="bg-white md:m-auto md:max-w-2/3">
+        {#each nodes as node}
+          <li class="flex justify-between border-b border-zinc-500 p-2">
+            <dd class="max-w-2/3 truncate">{node.alias}</dd>
+            <dt class="text-gray-600">{node.channels}</dt>
+          </li>
+        {/each}
+      </ol>
+    {:else}
+      <div class="m-auto mb-8 w-1/4 rounded-md bg-white p-8 text-center">
+        <h2 class="font-bold">{data.errorTitle}</h2>
+        <p>{data.errorMessage}</p>
+      </div>
+    {/if}
+  </div>
+  <footer class="flex bg-black text-sm text-white">
     <div id="footnotes">
       <ol>
         <li id="fn1">

--- a/src/routes/nodes/+page.ts
+++ b/src/routes/nodes/+page.ts
@@ -1,14 +1,61 @@
 import type { PageLoad } from './$types';
-import { error } from '@sveltejs/kit';
 import {
   PUBLIC_MEMPOOLSPACE_API_URL,
   PUBLIC_MEMPOOLSPACE_ENDPOINT_LN_RANKING_CONNECTIVITY,
 } from '$env/static/public';
 
-export const load: PageLoad = async ({ fetch }) => {
-  const url = `${PUBLIC_MEMPOOLSPACE_API_URL}${PUBLIC_MEMPOOLSPACE_ENDPOINT_LN_RANKING_CONNECTIVITY}`;
-  // TODO: error handling
-  const res = await fetch(url);
-  const nodes = await res.json();
-  return { nodes };
+// small utility function to have golang style error handling instead of try/catch blocks
+const catchError = (promise: Promise<any>) => {
+  return promise
+    .then((data) => {
+      return [null, data];
+    })
+    .catch((error) => {
+      return [error, null];
+    });
+};
+
+interface Node {
+  channels: Number;
+  alias: String;
+}
+interface NodesPageData {
+  nodes: Array<Node>;
+  errorTitle: null | String;
+  errorMessage: null | String;
+}
+export const load: PageLoad = async ({ fetch }): Promise<NodesPageData> => {
+  const url = `${PUBLIC_MEMPOOLSPACE_API_URL}${PUBLIC_MEMPOOLSPACE_ENDPOINT_LN_RANKING_CONNECTIVITY}`; // response ok and json
+  //const url = 'https://run.mocky.io/v3/048999b5-50b4-45fe-b277-cf03b852c17f'; // response ok and not json
+  //const url = "https://run.mocky.io/v3/01213725-e08e-447c-8472-f35d04a8ed84" // response not ok
+  // const url = 'https://run.sssssmocky.io/v3/01213725-e08e-447c-8472-f35d04a8ed84'; // failed to fetch
+
+  let errorTitle = null;
+  let errorMessage = null;
+
+  const [fetchError, res] = await catchError(fetch(url));
+  if (fetchError !== null) {
+    errorTitle = `Fetch Failed`;
+    errorMessage = fetchError.message;
+    console.error(fetchError);
+    return { errorTitle, errorMessage, nodes: [] };
+  }
+  if (res.ok === false) {
+    errorTitle = `API Error`;
+    errorMessage = `Response status ${res.status}`;
+    console.error(errorMessage);
+    console.error(res);
+    return { errorTitle, errorMessage, nodes: [] };
+  }
+
+  const [jsonError, nodes] = await catchError(res.json());
+  if (jsonError !== null) {
+    errorTitle = 'API Error';
+    errorMessage = 'API Error: Invalid JSON';
+    console.error(errorMessage);
+    console.error(jsonError);
+    return { errorTitle, errorMessage: 'Invalid JSON', nodes: [] };
+  }
+
+  return { errorTitle, errorMessage, nodes };
 };


### PR DESCRIPTION
This patch handles a set of 3 possible errors from a http GET fetch:
  - failed to fetch
  - response not ok
  - response ok, but body not parseable json